### PR TITLE
localList.html : 화살표 클릭시 지역별 스토리 상세 페이지로 이동

### DIFF
--- a/src/main/java/com/SoT/JIN/story/StoryController.java
+++ b/src/main/java/com/SoT/JIN/story/StoryController.java
@@ -5,6 +5,8 @@ import com.SoT.JIN.search.SearchService;
 import com.SoT.JIN.user.User;
 import com.SoT.JIN.user.UserRepository;
 import com.SoT.JIN.user.WriterController;
+import com.SoT.JIN.story.StoryGroupRepository;
+
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -35,9 +37,12 @@ public class StoryController {
     private final SearchService searchService;
     private final WriterController writerController;
     private final OpenAIService openAIService;
+    private final StoryGroupRepository storyGroupRepository;
 
     @Autowired
-    public StoryController(StoryRepository storyRepository, S3Service s3Service, StoryService storyService, UserRepository userRepository, SearchService searchService, WriterController writerController, OpenAIService openAIService) {
+    public StoryController(StoryRepository storyRepository, S3Service s3Service, StoryService storyService,
+                           UserRepository userRepository, SearchService searchService, WriterController writerController,
+                           OpenAIService openAIService, StoryGroupRepository storyGroupRepository) {
         this.storyRepository = storyRepository;
         this.s3Service = s3Service;
         this.storyService = storyService;
@@ -45,6 +50,7 @@ public class StoryController {
         this.searchService = searchService;
         this.writerController = writerController;
         this.openAIService = openAIService;
+        this.storyGroupRepository = storyGroupRepository; // 올바르게 주입
     }
 
     @PostMapping("/story/{storyId}/like")
@@ -286,5 +292,17 @@ public class StoryController {
         Map<String, List<Story>> groupedStories = storyService.getGroupedStories();
         model.addAttribute("groupedStories", groupedStories);
         return "localList";
+    }
+    @GetMapping("/localDetailPage")
+    public String getLocalDetailPage(@RequestParam("location") String location, Model model) {
+        List<Story> stories = storyService.getStoriesByLocation(location);
+        StoryGroup storyGroup = storyGroupRepository.findByGroupName(location)
+                .orElseThrow(() -> new IllegalArgumentException("Group not found"));
+
+        model.addAttribute("location", location);
+        model.addAttribute("stories", stories);
+        model.addAttribute("storyGroup", storyGroup);
+
+        return "localDetailPage"; // 해당 템플릿 페이지로 이동
     }
 }

--- a/src/main/java/com/SoT/JIN/story/StoryGroup.java
+++ b/src/main/java/com/SoT/JIN/story/StoryGroup.java
@@ -1,0 +1,33 @@
+package com.SoT.JIN.story;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+@Entity
+public class StoryGroup {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    private String groupName;      // 그룹 이름 (한글)
+    private String groupNameEn;    // 그룹 이름 (영문)
+    private String groupImage;     // 그룹 이미지 URL
+
+    // 기본 생성자
+    public StoryGroup() {}
+
+    // 필드를 초기화하는 생성자
+    public StoryGroup(String groupName, String groupNameEn, String groupImage) {
+        this.groupName = groupName;
+        this.groupNameEn = groupNameEn;
+        this.groupImage = groupImage;
+    }
+
+}

--- a/src/main/java/com/SoT/JIN/story/StoryGroupRepository.java
+++ b/src/main/java/com/SoT/JIN/story/StoryGroupRepository.java
@@ -1,0 +1,11 @@
+package com.SoT.JIN.story;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Optional;
+
+public interface StoryGroupRepository extends JpaRepository<StoryGroup, Long> {
+    boolean existsByGroupName(String groupName);
+    Optional<StoryGroup> findByGroupName(String groupName);
+
+}

--- a/src/main/java/com/SoT/JIN/story/StoryRepository.java
+++ b/src/main/java/com/SoT/JIN/story/StoryRepository.java
@@ -9,6 +9,8 @@ import org.springframework.stereotype.Repository;
 import java.util.List;
 @Repository
 public interface StoryRepository extends JpaRepository<Story, Long> {
+
+    List<Story> findByLocation(String location);
     // 사용자별 스토리 조회 (정렬 없음)
     List<Story> findByUsername(String username);
     List<Story> findByUsernameOrderByLikesDesc(String username);

--- a/src/main/java/com/SoT/JIN/story/StoryService.java
+++ b/src/main/java/com/SoT/JIN/story/StoryService.java
@@ -17,11 +17,15 @@ public class StoryService {
     private final StoryRepository storyRepository;
     private final LikeRepository likeRepository;
     private final SearchService searchService;
+    private final StoryGroupRepository storyGroupRepository;
+
     @Autowired
-    public StoryService(StoryRepository storyRepository, LikeRepository likeRepository, SearchService searchService) {
+    public StoryService(StoryRepository storyRepository, LikeRepository likeRepository,
+                        SearchService searchService, StoryGroupRepository storyGroupRepository) {
         this.storyRepository = storyRepository;
         this.likeRepository = likeRepository;
         this.searchService = searchService;
+        this.storyGroupRepository = storyGroupRepository;
     }
     @Transactional
     public Story getStoryAndIncrementViewCount(Long id) {
@@ -74,7 +78,14 @@ public class StoryService {
                 .entrySet().stream()
                 .filter(entry -> entry.getValue().size() >= 3) // 3개 이상의 스토리만 필터링
                 .collect(Collectors.toMap(Map.Entry::getKey, entry -> entry.getValue().subList(0, Math.min(3, entry.getValue().size()))));
-
+        // 새로운 그룹 이름으로 StoryGroup 엔티티 생성
+        groupedStories.keySet().forEach(groupName -> {
+            if (!storyGroupRepository.existsByGroupName(groupName)) {
+                // 여기서는 그룹 이름만으로 엔티티를 생성합니다.
+                StoryGroup newGroup = new StoryGroup(groupName, null, null); // 영문 이름과 이미지 URL은 null로 설정
+                storyGroupRepository.save(newGroup);
+            }
+        });
         return groupedStories;
     }
 
@@ -82,6 +93,9 @@ public class StoryService {
     private List<Story> getAllStories() {
         // DB에서 스토리 가져오는 로직이 들어갑니다.
         return storyRepository.findAll(); // 예시로 storyRepository를 사용
+    }
+    public List<Story> getStoriesByLocation(String location) {
+        return storyRepository.findByLocation(location); // 해당 위치의 스토리만 필터링하여 가져오기
     }
 
 }

--- a/src/main/resources/templates/localDetailPage.html
+++ b/src/main/resources/templates/localDetailPage.html
@@ -1,0 +1,29 @@
+<!DOCTYPE html>
+<html lang="ko">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Local Detail Page</title>
+  <link rel="stylesheet" th:href="@{/css/localDetailPage.css}">
+</head>
+<body>
+
+<!-- 스토리 그룹 정보 표시 -->
+<div>
+  <h1 th:text="${storyGroup.groupName}"></h1>
+  <h2 th:text="${storyGroup.groupNameEn}"></h2>
+  <div>
+    <img th:src="@{${storyGroup.groupImage}}"/>
+  </div>
+</div>
+
+<!-- 각 스토리 정보 표시 -->
+<div th:each="story : ${stories}">
+  <h2 th:text="${story.title}">스토리 제목</h2>
+  <img th:src="@{${story.image_url}}" alt="스토리 이미지" />
+  <p th:text="'조회수: ' + ${story.viewCount}">조회수</p>
+  <p th:text="'좋아요 수: ' + ${story.likesCount}">좋아요 수</p>
+</div>
+
+</body>
+</html>

--- a/src/main/resources/templates/localList.html
+++ b/src/main/resources/templates/localList.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html lang="ko">
+<html lang="ko" xmlns="http://www.w3.org/1999/html">
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
@@ -91,13 +91,14 @@
                   </p>
                 </div>
                 <img
-                  th:src="@{/images/localarrow.png}"
-                  alt="더보기 화살표"
-                  id="localarrow"
-                  width="24px"
-                  height="24px"
-                  style="cursor: pointer"
-                  onclick="location.href='a.html'"
+                        th:src="@{/images/localarrow.png}"
+                        alt="더보기 화살표"
+                        id="localarrow"
+                        width="24px"
+                        height="24px"
+                        style="cursor: pointer"
+                        th:data-location="${entry.key}"
+                        onclick="redirectToDetailPage(this)"
                 />
               </div>
               <div id="localImagegroup">
@@ -116,5 +117,11 @@
       </div>
     </div>
   <script th:src="@{/js/Home.js}"></script>
+  <script>
+    function redirectToDetailPage(element) {
+      var location = element.getAttribute('data-location');
+      window.location.href = '/localDetailPage?location=' + encodeURIComponent(location);
+    }
+  </script>
   </body>
 </html>


### PR DESCRIPTION
localDetailPage.html : 지역별 스토리 상세 페이지 제작(그룹 스토리 이름, 그룹 스토리 영문, 그룹 스토리 이미지, 각 스토리 제목+이미지+조회수+좋아요수)
StoryGroup : StoryGroup 엔티티 생성(그룹 이름, 그룹이름(영문), 그룹 이미지)
StoryService 수정 : 같은 위치의 스토리가 3개 이상이라 그룹 생성시 해당 위치 이름으로 StoryGroup 엔티티 생성, 해당 위치의 스토리만 가져오는 메소드 추가
StoryRepository : 위치를 바탕으로 Story 가져오기
StoryController : 지역별 스토리 상세 페이지 매핑 추가(위치+스토리들+스토리그룹 모델로 전달)
StoryGroupRepository : GroupName으로 엔티티 생성을 도와주는 메소드, StoryGroup이 존재하는지 확인하는 메소드 추가