### PR TITLE
Backjin

### DIFF
--- a/src/main/java/com/SoT/JIN/CustomAuthenticationFailureHandler.java
+++ b/src/main/java/com/SoT/JIN/CustomAuthenticationFailureHandler.java
@@ -1,0 +1,24 @@
+package com.SoT.JIN;
+
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import org.springframework.security.core.AuthenticationException;
+import org.springframework.security.web.authentication.AuthenticationFailureHandler;
+import org.springframework.stereotype.Component;
+
+import java.io.IOException;
+
+@Component
+public class CustomAuthenticationFailureHandler implements AuthenticationFailureHandler {
+
+    @Override
+    public void onAuthenticationFailure(HttpServletRequest request, HttpServletResponse response,
+                                        AuthenticationException exception) throws IOException, ServletException {
+        // JSON 형식으로 로그인 실패 메시지 반환 (UTF-8로 인코딩 설정)
+        response.setStatus(HttpServletResponse.SC_UNAUTHORIZED);
+        response.setContentType("application/json; charset=UTF-8");
+        response.setCharacterEncoding("UTF-8");  // 인코딩 설정
+        response.getWriter().write("{\"message\": \"이메일 또는 비밀번호가 일치하지 않습니다.\"}");
+    }
+}

--- a/src/main/java/com/SoT/JIN/SecurityConfig.java
+++ b/src/main/java/com/SoT/JIN/SecurityConfig.java
@@ -4,17 +4,17 @@ import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
-import org.springframework.security.config.annotation.web.configurers.AuthorizeHttpRequestsConfigurer;
-import org.springframework.security.config.annotation.web.configurers.FormLoginConfigurer;
 import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.security.web.SecurityFilterChain;
+import org.springframework.beans.factory.annotation.Autowired;
 
 @Configuration
 @EnableWebSecurity
 public class SecurityConfig {
-    public SecurityConfig() {
-    }
+
+    @Autowired
+    private CustomAuthenticationFailureHandler customAuthenticationFailureHandler;
 
     @Bean
     PasswordEncoder passwordEncoder() {
@@ -29,12 +29,20 @@ public class SecurityConfig {
         http.authorizeHttpRequests((authorize) -> {
             authorize.requestMatchers("/**").permitAll();
         });
+
         http.formLogin((formLogin) -> {
-            formLogin.loginPage("/login").defaultSuccessUrl("/home").failureUrl("/error");
+            formLogin.loginPage("/login")
+                    .defaultSuccessUrl("/home")
+                    .failureHandler(customAuthenticationFailureHandler); // 실패 핸들러 적용
         });
+
         http.logout((logout) -> {
-            logout.logoutUrl("/logout").logoutSuccessUrl("/home").invalidateHttpSession(true).deleteCookies("JSESSIONID");
+            logout.logoutUrl("/logout")
+                    .logoutSuccessUrl("/home")
+                    .invalidateHttpSession(true)
+                    .deleteCookies("JSESSIONID");
         });
+
         return http.build();
     }
 }

--- a/src/main/java/com/SoT/JIN/rising/RisingController.java
+++ b/src/main/java/com/SoT/JIN/rising/RisingController.java
@@ -1,5 +1,6 @@
 package com.SoT.JIN.rising;
 
+import com.SoT.JIN.search.SearchService;
 import com.SoT.JIN.story.Story;
 import com.SoT.JIN.story.StoryService;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -18,11 +19,13 @@ public class RisingController {
 
     private final RisingService risingService;
     private final StoryService storyService;
+    private final SearchService searchService;
 
     @Autowired
-    public RisingController(RisingService risingService, StoryService storyService) {
+    public RisingController(RisingService risingService, StoryService storyService, SearchService searchService) {
         this.risingService = risingService;
         this.storyService = storyService;
+        this.searchService = searchService;
     }
 
     @GetMapping("/rise/{keyword}")
@@ -30,6 +33,9 @@ public class RisingController {
                                       @RequestParam(value = "sort", required = false) String sortCriteria,
                                       @RequestParam(name = "limit", defaultValue = "24") int limit,
                                       Model model) {
+
+        // 1. 키워드에 해당하는 Search 카운트 증가
+        searchService.saveSearchKeyword(keyword);  // Search 카운트 증가
         // 1. 키워드에 해당하는 Rising 엔티티 조회
         Rising rising = risingService.findByKeyword(keyword)
                 .orElseThrow(() -> new IllegalArgumentException("급상승 키워드를 찾을 수 없습니다: " + keyword));

--- a/src/main/java/com/SoT/JIN/rising/RisingService.java
+++ b/src/main/java/com/SoT/JIN/rising/RisingService.java
@@ -10,6 +10,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Sort;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -78,14 +79,17 @@ public class RisingService {
         logger.info("Fetched Rising entities: " + risings.size());  // 로그 메시지 추가
         return risings;
     }
-    // 특정 키워드에 해당하는 가장 작은 ID를 가진 Story를 가져오기
     public Story getStoryWithSmallestId(String keyword) {
-        List<Long> storyIds = storyRepository.findIdsByKeyword(keyword);
+        // 1개의 결과만 가져오는 Pageable 설정
+        Pageable pageable = PageRequest.of(0, 1);  // 첫 번째 페이지에서 한 개의 ID만 가져옴
+        List<Long> storyIds = storyRepository.findIdsByKeyword(keyword, pageable);
+
         if (storyIds.isEmpty()) {
             return null;
         }
-        Long smallestId = storyIds.stream().min(Long::compare).orElse(null);
-        return storyRepository.findById(smallestId).orElse(null);
+
+        Long smallestId = storyIds.get(0);  // 가장 작은 ID 가져오기 (첫 번째 값)
+        return storyRepository.findById(smallestId).orElse(null);  // 해당 스토리 조회
     }
     // 특정 키워드를 제외한 상위 6개의 Rising 키워드에 해당하는 Story 가져오기
     public Map<Rising, Story> getTopStoriesExcludingKeyword(String excludeKeyword, int limit) {

--- a/src/main/java/com/SoT/JIN/search/SearchController.java
+++ b/src/main/java/com/SoT/JIN/search/SearchController.java
@@ -37,7 +37,7 @@ public class SearchController {
         searchService.saveSearchKeyword(query);
 
         // 검색어에 따른 스토리 검색
-        List<Story> stories = storyRepository.findByTitleContainingIgnoreCase(query);
+        List<Story> stories = storyRepository.findByTitleContainingIgnoreCaseOrderByStoryIdDesc(query);
         List<Story> limitedStories = stories.stream().limit(limit).collect(Collectors.toList());
 
         // 모델에 검색 결과 추가
@@ -78,7 +78,7 @@ public class SearchController {
     @ResponseBody
     public Map<String, Object> getSearchCount(@RequestParam("query") String query) {
         // 검색어에 따른 스토리 검색
-        List<Story> stories = storyRepository.findByTitleContainingIgnoreCase(query);
+        List<Story> stories = storyRepository.findByTitleContainingIgnoreCaseOrderByStoryIdDesc(query);
 
         // 결과를 JSON 형식으로 반환
         Map<String, Object> response = new HashMap<>();

--- a/src/main/java/com/SoT/JIN/search/SearchService.java
+++ b/src/main/java/com/SoT/JIN/search/SearchService.java
@@ -4,6 +4,8 @@ import com.SoT.JIN.rising.RisingService;
 import com.SoT.JIN.story.Story;
 import com.SoT.JIN.story.StoryRepository;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -71,11 +73,14 @@ public class SearchService {
     }
 
     public Story getStoryWithSmallestId(String keyword) {
-        List<Long> storyIds = storyRepository.findIdsByKeyword(keyword);
-        if (storyIds.isEmpty()) {
+        Pageable pageable = PageRequest.of(0, 1); // 1개의 결과만 가져옴
+        List<Long> largestStoryIds = storyRepository.findIdsByKeyword(keyword, pageable);
+
+        if (largestStoryIds.isEmpty()) {
             return null;
         }
-        Long smallestId = storyIds.stream().min(Long::compare).orElse(null);
-        return storyRepository.findById(smallestId).orElse(null);
+
+        Long largestId = largestStoryIds.get(0);
+        return storyRepository.findById(largestId).orElse(null);
     }
 }

--- a/src/main/java/com/SoT/JIN/story/StoryRepository.java
+++ b/src/main/java/com/SoT/JIN/story/StoryRepository.java
@@ -28,11 +28,12 @@ public interface StoryRepository extends JpaRepository<Story, Long> {
     // 사용자별 게시글 수를 세는 메서드
     long countByUsername(String username);
 
-    List<Story> findByTitleContainingIgnoreCase(String query);
+    List<Story> findByTitleContainingIgnoreCaseOrderByStoryIdDesc(String query);
 
-    // 특정 키워드가 포함된 스토리 ID 조회
-    @Query("SELECT s.storyId FROM Story s WHERE s.tags LIKE %:keyword% OR s.description LIKE %:keyword% OR s.location LIKE %:keyword% OR s.title LIKE %:keyword%")
-    List<Long> findIdsByKeyword(String keyword);
+
+    // 특정 키워드가 포함된 스토리 ID 중 가장 큰 ID 조회
+    @Query("SELECT s.storyId FROM Story s WHERE s.tags LIKE %:keyword% OR s.description LIKE %:keyword% OR s.location LIKE %:keyword% OR s.title LIKE %:keyword% ORDER BY s.storyId DESC")
+    List<Long> findIdsByKeyword(String keyword, Pageable pageable);
 
     List<Story> findByThemeContaining(String selectedTheme);
 

--- a/src/main/java/com/SoT/JIN/story/StoryService.java
+++ b/src/main/java/com/SoT/JIN/story/StoryService.java
@@ -7,6 +7,8 @@ import com.SoT.JIN.like.LikeRepository;
 import com.SoT.JIN.user.User;
 import com.SoT.JIN.user.UserRepository;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -53,8 +55,17 @@ public class StoryService {
     }
 
     public List<Story> findStoriesByKeyword(String keyword) {
-        Set<Long> storyIds = storyRepository.findIdsByKeyword(keyword).stream().collect(Collectors.toSet());
-        return storyRepository.findAllById(storyIds);
+        // 필요한 만큼의 페이지 크기 설정 (예: 100개씩 가져오기)
+        Pageable pageable = PageRequest.of(0, 100);  // 100개씩 가져옴
+        List<Long> storyIds = storyRepository.findIdsByKeyword(keyword, pageable);
+
+        if (storyIds.isEmpty()) {
+            return Collections.emptyList();  // ID가 없으면 빈 리스트 반환
+        }
+
+        // ID 리스트를 Set으로 변환 후, 모든 스토리를 조회
+        Set<Long> storyIdSet = storyIds.stream().collect(Collectors.toSet());
+        return storyRepository.findAllById(storyIdSet);  // 해당 ID들로 스토리 조회
     }
 
     public Map<String, List<Story>> getGroupedStories() {
@@ -139,9 +150,6 @@ public class StoryService {
         }
     }
 
-    public List<Story> searchStoriesByTitle(String title) {
-        return storyRepository.findByTitleContainingIgnoreCase(title);
-    }
     public List<Story> getSeasonStories(String season, int limit) {
         List<Story> stories = storyRepository.findAll();
         List<Story> seasonStories = stories.stream()

--- a/src/main/java/com/SoT/JIN/user/PasswordController.java
+++ b/src/main/java/com/SoT/JIN/user/PasswordController.java
@@ -6,6 +6,8 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.web.bind.annotation.*;
 
+import java.util.HashMap;
+import java.util.Map;
 import java.util.Optional;
 import java.util.UUID;
 
@@ -51,11 +53,27 @@ public class PasswordController {
 
     }
     @PostMapping("/forgot-password")
-    public ResponseEntity<String> forgotPassword(@RequestParam("email") String email) {
+    public ResponseEntity<Map<String, String>> forgotPassword(@RequestParam("email") String email) {
         User user = userService.findByEmail(email);
 
+        Map<String, String> response = new HashMap<>();
+
+        // 사용자가 존재하지 않을 때의 처리
         if (user == null) {
-            return ResponseEntity.status(400).body("해당 이메일이 존재하지 않습니다.");
+            response.put("message", "해당 이메일이 존재하지 않습니다.");
+            return ResponseEntity.status(400).body(response);
+        }
+
+// 이미 비밀번호 재설정 토큰이 있는지 확인
+        PasswordResetToken existingToken = tokenService.findByUser(user);
+        if (existingToken != null && !existingToken.isExpired()) {
+            response.put("message", "이미 비밀번호 재설정 요청이 처리되었습니다. 이메일을 확인하세요.");
+            return ResponseEntity.status(400).body(response);
+        }
+
+// 만료된 토큰이 있으면 삭제 또는 무효화
+        if (existingToken != null && existingToken.isExpired()) {
+            tokenService.invalidateToken(existingToken.getToken());  // 만료된 토큰 무효화
         }
 
         // 비밀번호 재설정 토큰 생성
@@ -69,7 +87,8 @@ public class PasswordController {
         emailService.sendEmail(user.getEmail(), "비밀번호 재설정 링크",
                 "비밀번호를 재설정하려면 다음 링크를 클릭하세요: " + resetLink);
 
-        return ResponseEntity.ok("비밀번호 재설정 링크가 이메일로 전송되었습니다.");
+        response.put("message", "비밀번호 재설정 링크가 이메일로 전송되었습니다.");
+        return ResponseEntity.ok(response);
     }
 
     // 비밀번호 재설정 링크 생성 메서드

--- a/src/main/java/com/SoT/JIN/user/PasswordResetToken.java
+++ b/src/main/java/com/SoT/JIN/user/PasswordResetToken.java
@@ -20,6 +20,23 @@ public class PasswordResetToken {
     @OneToOne
     @JoinColumn(name = "user_id", referencedColumnName = "userId")
     private User user;
+    // 만료 시간 계산
+    public void setExpiryDate(int minutes) {
+        this.expiryDate = LocalDateTime.now().plusMinutes(minutes);  // 예: 30분 후 만료
+    }
 
     private LocalDateTime expiryDate; // 토큰 만료 시간
+    // 토큰이 만료되었는지 확인하는 메서드 추가
+    public boolean isExpired() {
+        return LocalDateTime.now().isAfter(this.expiryDate);
+    }
+
+    // getter, setter 및 다른 필요한 메서드들
+    public LocalDateTime getExpiryDate() {
+        return expiryDate;
+    }
+
+    public void setExpiryDate(LocalDateTime expiryDate) {
+        this.expiryDate = expiryDate;
+    }
 }

--- a/src/main/java/com/SoT/JIN/user/PasswordResetTokenRepository.java
+++ b/src/main/java/com/SoT/JIN/user/PasswordResetTokenRepository.java
@@ -9,4 +9,6 @@ public interface PasswordResetTokenRepository extends JpaRepository<PasswordRese
     void deleteByToken(String token);
 
     void deleteByUser(User user); // 사용자를 기반으로 토큰 삭제
+
+    PasswordResetToken findByUser(User user);
 }

--- a/src/main/java/com/SoT/JIN/user/PasswordResetTokenService.java
+++ b/src/main/java/com/SoT/JIN/user/PasswordResetTokenService.java
@@ -47,4 +47,7 @@ public class PasswordResetTokenService {
     public void invalidateToken(String token) {
         tokenRepository.deleteByToken(token);
     }
+    public PasswordResetToken findByUser(User user) {
+        return tokenRepository.findByUser(user);
+    }
 }

--- a/src/main/java/com/SoT/JIN/user/UserRepository.java
+++ b/src/main/java/com/SoT/JIN/user/UserRepository.java
@@ -20,4 +20,10 @@ public interface UserRepository extends JpaRepository<User, Long> {
 
     // 전화번호가 존재하는지 확인하는 메서드
     boolean existsByPhoneNumber(String phoneNumber);
+
+    // 이메일 중복 확인 메소드
+    boolean existsByEmail(String email);
+
+    // 닉네임 중복 확인 메소드
+    boolean existsByUsername(String username);
 }

--- a/src/main/resources/static/css/Home.css
+++ b/src/main/resources/static/css/Home.css
@@ -2321,7 +2321,7 @@ input:focus {
 
 /* 팔로우 취소 팝업창 시작 */
 #bg_gray10 {
-  position: absolute;
+  position: fixed;
   display: none; /* 버튼이 안눌러지면 display:none */
   top: 0;
   left: 0;

--- a/src/main/resources/static/css/Home.css
+++ b/src/main/resources/static/css/Home.css
@@ -1,6 +1,16 @@
 .myButton.selected {
   color: #000; /* 선택된 버튼의 글씨 색상을 검정색으로 강제 변경 */
 }
+/* 에러 메시지 공간을 미리 확보 */
+.idandpwcheck-content {
+  height: 20px; /* 미리 공간을 확보 */
+  color: red;
+  visibility: hidden; /* 기본적으로 안 보이게 설정 */
+}
+
+.idandpwcheck-content.show {
+  visibility: visible; /* 에러가 발생했을 때만 보이게 설정 */
+}
 .bh {
   text-decoration: none;
   color: #000;
@@ -451,7 +461,7 @@ input::placeholder {
 }
 #bg_gray {
   /* 로그인 창이 떴을 때 뒷배경 회색처리 */
-  position: absolute;
+  position: fixed;
   display: none; /* 버튼이 안눌러지면 display:none */
   top: 0;
   left: 0;

--- a/src/main/resources/static/js/Home.js
+++ b/src/main/resources/static/js/Home.js
@@ -1,3 +1,70 @@
+// 페이지가 완전히 로드된 후 팝업 숨김 처리
+document.addEventListener('DOMContentLoaded', function() {
+  document.getElementById('bg_gray').style.display = 'none';
+});
+
+// AJAX를 통해 로그인 폼 제출
+function submitLoginForm() {
+  const username = document.querySelector('#email_input').value;
+  const password = document.querySelector('#pw_input').value;
+
+  // 오류 메시지 초기화
+  const errorMessageElement = document.getElementById('error-message');
+  errorMessageElement.textContent = '';  // 기존 메시지 제거
+  errorMessageElement.classList.remove('show');  // 에러 메시지 숨기기
+
+  fetch('/login', {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/x-www-form-urlencoded',
+    },
+    body: new URLSearchParams({ username: username, password: password })
+  })
+      .then(response => {
+        if (!response.ok) {
+          // 실패 시 JSON 응답을 받아서 에러 메시지 출력
+          return response.json().then(err => { throw new Error(err.message); });
+        }
+        return response.text();  // 성공 시
+      })
+      .then(data => {
+        // 로그인 성공 시 메인 페이지로 이동
+        window.location.href = '/home';
+      })
+      .catch(error => {
+        // 로그인 실패 시 error-message 요소에 에러 메시지 표시
+        errorMessageElement.textContent = error.message;
+        errorMessageElement.classList.add('show');  // 에러 메시지 보이게 설정
+      });
+}
+
+function submitPwFindForm() {
+  const email = document.querySelector('#email_input11').value;
+
+  fetch('/forgot-password', {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/x-www-form-urlencoded',
+    },
+    body: new URLSearchParams({ email: email })
+  })
+      .then(response => {
+        if (!response.ok) {
+          return response.json().then(err => { throw new Error(err.message); });
+        }
+        return response.json();
+      })
+      .then(data => {
+        // 성공 시 'bg_gray9' 팝업을 띄움
+
+        document.getElementById("bg_gray8").style.display = "none";
+        document.getElementById("bg_gray9").style.display = "block";
+
+      })
+      .catch(error => {
+        alert(error.message);  // 실패 시 에러 메시지를 alert로 표시
+      });
+}
 document.addEventListener("DOMContentLoaded", function () {
   var Joinbtn = document.querySelector("#join"); // 로그인 버튼
   var loginLabel = document.getElementById("loginLabel"); // 로그인 라벨

--- a/src/main/resources/templates/Home.html
+++ b/src/main/resources/templates/Home.html
@@ -166,6 +166,7 @@
     <div th:replace="~{fragments/terms_footer_popup :: terms_footer}"></div>
     <div th:replace="~{fragments/pwfind_popup :: pwFindPopup}"></div>
     <div th:replace="~{fragments/changepw_popup :: changePwPopup}"></div>
+    <div th:replace="~{fragments/pwfindsendnotice_popup :: pwFindSendNoticePopup}"></div>
 
     <!-- 슬라이드 광고 시작 -->
     <div class="slide-container">

--- a/src/main/resources/templates/following.html
+++ b/src/main/resources/templates/following.html
@@ -124,14 +124,24 @@
                     height="10px"
             >
             <p class="following-status">팔로우중</p>
-            <img
-                    th:src="@{/images/follow_x.png}"
-                    class="follow_x"
-                    width="16px"
-                    height="16px"
-                    alt="팔로우 취소"
-                    onclick="document.getElementById('bg_gray10').style.display='block';"
-            />
+            <!-- 팔로우 취소 버튼 (x 버튼) -->
+            <form th:action="@{'/writer/' + ${follow.username} + '/unfollow'}" method="post" style="display: inline;">
+              <button type="submit" style="border: none; background: none;">
+                <img
+                        th:src="@{/images/follow_x.png}"
+                        class="follow_x"
+                        width="16px"
+                        height="16px"
+                        alt="팔로우 취소"
+                />
+              </button>
+            </form>
+            <!-- 팝업 -->
+            <div id="bg_gray10" style="display: none" th:fragment="followCancelPopup">
+              <p>정말로 팔로우를 취소하시겠습니까?</p>
+              <button type="button" onclick="confirmUnfollow()">확인</button>
+              <button type="button" onclick="closeUnfollowPopup()">취소</button>
+            </div>
           </div>
 
           <div class="follow2">
@@ -177,6 +187,30 @@
 </div>
 <!-- 팔로잉 페이지 끝 -->
 <script>
+  let currentForm = null;  // 현재 제출될 폼을 저장
+
+  // 폼 제출 이벤트를 가로채고 팝업 띄우기
+  document.querySelectorAll('form').forEach(form => {
+    form.addEventListener('submit', function (event) {
+      event.preventDefault();  // 폼 제출 중단
+      currentForm = this;  // 현재 폼 저장
+      document.getElementById('bg_gray10').style.display = 'block';  // 팝업 표시
+    });
+  });
+
+  // 팝업 닫기
+  function closeUnfollowPopup() {
+    document.getElementById('bg_gray10').style.display = 'none';
+    currentForm = null;  // 폼 초기화
+  }
+
+  // 팝업에서 '확인'을 누르면 폼 제출 진행
+  function confirmUnfollow() {
+    if (currentForm) {
+      currentForm.submit();  // 폼 제출
+    }
+    closeUnfollowPopup();  // 팝업 닫기
+  }
   document.addEventListener("DOMContentLoaded", function () {
     document.querySelectorAll('.following-item').forEach(function(item) {
       var content = item.querySelector('.content');

--- a/src/main/resources/templates/fragments/followcancel_popup.html
+++ b/src/main/resources/templates/fragments/followcancel_popup.html
@@ -20,12 +20,12 @@
             <button
                     id="closefollowcancelbtn"
                     type="button"
-                    onclick="document.getElementById('bg_gray10').style.display='none';"
+                    onclick="closeUnfollowPopup();"
             >
                 닫기
             </button>
             <!-- 취소하기 버튼 클릭 시 form 제출 -->
-            <button id="closefollowcancelbtn2" type="button" onclick="submitUnfollowForm()">
+            <button id="closefollowcancelbtn2" type="button" onclick="confirmUnfollow()">
                 취소하기
             </button>
         </div>

--- a/src/main/resources/templates/fragments/pwfind_popup.html
+++ b/src/main/resources/templates/fragments/pwfind_popup.html
@@ -18,7 +18,7 @@
       </div>
     </div>
     <!-- 이메일 전송 폼 -->
-    <form action="/forgot-password" method="POST">
+    <form id="pwFindForm">
       <div class="join_input11">
         <div id="text2">이메일</div>
         <label for="email_input11">
@@ -29,8 +29,8 @@
         <img th:src="@{/images/pwfindnotice.png}" id="pwfindnotice" alt="안내표시" width="22px" height="22px" />
         <p id="pwfindnoticetext">입력된 이메일로 비밀번호 변경 링크를 보내드립니다.</p>
       </div>
-      <!-- 확인 버튼: 폼 제출 -->
-      <button id="pwfindcheckbtn" type="submit">확인</button>
+      <!-- 확인 버튼: AJAX로 폼 제출 -->
+      <button id="pwfindcheckbtn" type="button" onclick="submitPwFindForm()">확인</button>
     </form>
   </div>
 </div>

--- a/src/main/resources/templates/fragments/pwfindsendnotice_popup.html
+++ b/src/main/resources/templates/fragments/pwfindsendnotice_popup.html
@@ -46,18 +46,22 @@
           이메일을 통해 비밀변호를 변경해주세요.
         </div>
 
-        <button id="pwfindsendnoticecbtn">확인</button>
+        <button id="pwfindsendnoticecbtn" onclick="document.getElementById('bg_gray9').style.display='none';">
+          확인
+        </button>
+
       </div>
     </div>
     <script>
       document.addEventListener("DOMContentLoaded", function () {
         var Joinbtn = document.querySelector("#emailfindcheckbtn");
         var joinfinishPopup = document.getElementById("bg_gray9");
+        var closeBtn = document.getElementById("pwfindsendnoticecbtn"); // 확인 버튼
 
         // 로그인 버튼 누르면 회원가입창 열기
-        Joinbtn.addEventListener("click", function (event) {
+        closeBtn.addEventListener("click", function (event) {
           event.preventDefault(); // 링크의 기본 동작 방지
-          joinfinishPopup.style.display = "block"; // 로그인 팝업 보이기
+          document.getElementById('bg_gray9').style.display='none'; // 로그인 팝업 보이기
         });
       });
     </script>

--- a/src/main/resources/templates/resetpassword.html
+++ b/src/main/resources/templates/resetpassword.html
@@ -1,75 +1,134 @@
 <!DOCTYPE html>
-<html lang="en">
+<html lang="ko" xmlns:th="http://www.thymeleaf.org">
 <head>
-    <meta charset="UTF-8">
-    <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>비밀번호 변경</title>
-    <style>
-        body {
-            font-family: Arial, sans-serif;
-            display: flex;
-            justify-content: center;
-            align-items: center;
-            height: 100vh;
-            margin: 0;
-        }
-        .container {
-            width: 300px;
-            padding: 20px;
-            border: 1px solid #ddd;
-            border-radius: 10px;
-            background-color: #f9f9f9;
-        }
-        input[type="password"], button {
-            width: 100%;
-            padding: 10px;
-            margin: 10px 0;
-            border: 1px solid #ccc;
-            border-radius: 5px;
-        }
-        button {
-            background-color: #28a745;
-            color: white;
-            border: none;
-            cursor: pointer;
-        }
-        button:hover {
-            background-color: #218838;
-        }
-    </style>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+
+    <!-- CSS 파일 경로 (Thymeleaf로 동적 처리 가능) -->
+    <link rel="stylesheet" th:href="@{/css/changenewpw.css}" />
+    <link rel="stylesheet" th:href="@{/css/footer.css}" />
+    <link rel="stylesheet" th:href="@{/css/nav.css}" />
+
+    <link
+            rel="stylesheet"
+            type="text/css"
+            href="https://cdn.jsdelivr.net/gh/orioncactus/pretendard/dist/web/static/pretendard.css"
+    />
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <link href="https://fonts.googleapis.com/css2?family=Noto+Sans+KR:wght@100..900&display=swap" rel="stylesheet" />
+
+    <title>SoT - 비밀번호 변경</title>
 </head>
 <body>
-<div class="container">
-    <input type="hidden" id="token" name="token" th:value="${token}">
-    <h2>비밀번호 변경</h2>
-    <form id="resetPasswordForm">
-        <label for="newPassword">새 비밀번호:</label>
-        <input type="password" id="newPassword" name="newPassword" required>
+<!-- 내비게이션바 -->
+<nav class="navbar">
+    <div class="nav_logo">
+        <div id="nav_left">
+            <!-- 로고 -->
+            <div id="nav_logo1">
+                <a href="./home">
+                    <img th:src="@{/images/MainLogo.png}" alt="로고" width="200px" height="46px" />
+                </a>
+            </div>
+            <!-- 메뉴바 -->
+            <div class="nav_menu">
+                <ul class="navigation">
+                    <li><a href="/home" class="bh">홈</a></li>
+                    <li><a href="./local" class="c">지역</a></li>
+                    <li><a href="./popular" class="d">인기 작가</a></li>
+                </ul>
+            </div>
+            <!-- 검색바 -->
+            <form action="/search" method="get" id="search">
+                <input type="text" name="query" class="search" />
+                <button type="submit" id="searchBtn" style="background: none; border: none;">
+                    <img th:src="@{/images/search.png}" alt="돋보기" id="searchIcon" width="30px" height="30px" />
+                </button>
+            </form>
+        </div>
+        <div id="nav_right">
+            <input type="button" class="followingbtn" style="display: none" onclick="location.href='follows'" />
+            <input type="button" class="imagebtn" style="display: none" onclick="location.href='bookmark'" />
+            <input type="button" id="uploadbtn" style="display: none" />
 
-        <label for="confirmPassword">새 비밀번호 확인:</label>
-        <input type="password" id="confirmPassword" name="confirmPassword" required>
+            <input type="checkbox" id="join" style="display: none" />
+            <label for="join" id="loginLabel" onclick="toggleDropdown()">로그인</label>
+            <!-- 드롭다운 메뉴 -->
+            <div id="dropdownMenu" class="dropdown-content" style="display: none">
+                <button onclick="location.href='/my-page'">마이페이지</button>
+                <button onclick="document.getElementById('bg_gray11').style.display='block';">비밀번호 변경</button>
+                <form action="/logout" method="post">
+                    <button type="submit">로그아웃</button>
+                </form>
+            </div>
+        </div>
+    </div>
+</nav>
 
-        <button type="button" onclick="resetPassword()">비밀번호 변경</button>
-    </form>
+<!-- 비밀번호 변경 섹션 -->
+<div id="changenewpwLink">
+    <div id="changenewpwLink1">
+        <div id="changenewpwLinkTitle">
+            <p id="changenewpwLinktitle1">비밀번호 변경</p>
+        </div>
+
+        <!-- 비밀번호 변경 폼 시작 -->
+        <form id="resetPasswordForm">
+            <input type="hidden" id="token" name="token" th:value="${token}">
+
+            <div id="newpwpart1">
+                <div id="newpwparttext1">
+                    <p id="currentpwparttext11">새 비밀번호</p>
+                    <div id="check_pw11">
+                        <span id="text2411">특수문자 포함</span>
+                        <div id="imageContainer111" style="display: none">
+                            <img id="check_img111" th:src="@{/images/check.png}" alt="check" width="8px" height="5px" />
+                        </div>
+                        <div id="middle311"></div>
+                        <span id="text2511">8자 이상</span>
+                        <div id="imageContainer211" style="display: none">
+                            <img id="check_img211" th:src="@{/images/check.png}" alt="check" width="8px" height="5px" />
+                        </div>
+                    </div>
+                </div>
+                <input type="password" id="newPassword" oninput="checkInputs1p1()" required />
+            </div>
+
+            <div id="recheckpwpart1">
+                <div id="recheckpwparttext1">
+                    <p id="recheckpwparttext11">새 비밀번호 확인</p>
+                    <p id="recheckpwparttext21" style="color: red"></p>
+                </div>
+                <input type="password" id="confirmPassword" oninput="checkPasswordsMatchp1()" required />
+            </div>
+
+            <button type="button" id="changenewpwbtn" onclick="resetPassword()">확인</button>
+        </form>
+        <!-- 비밀번호 변경 폼 끝 -->
+    </div>
 </div>
 
+<!-- 푸터 -->
+<div id="Footer">
+    <button class="footer_1" onclick="showPopupf('bg_gray33')">개인정보처리방침</button>
+    <button class="footer_2" onclick="showPopupf('bg_gray44')">이용약관</button>
+    <p class="email">Contact. Story.of.Travel.official@gmail.com</p>
+    <p class="SoT_2024">© 2024 SoT. All rights reserved.</p>
+</div>
+
+<!-- JavaScript 부분 -->
 <script>
     function resetPassword() {
         const token = document.querySelector('#token').value;
         const newPassword = document.querySelector('#newPassword').value;
         const confirmPassword = document.querySelector('#confirmPassword').value;
 
-        // 비밀번호 확인
         if (newPassword !== confirmPassword) {
             alert("비밀번호가 일치하지 않습니다.");
             return;
         }
 
-        // 토큰과 새 비밀번호가 제대로 설정되었는지 확인
-        console.log("Token:", token);
-        console.log("New Password:", newPassword);
-
-        // 비밀번호 변경 요청
         fetch('/reset-password', {
             method: 'POST',
             headers: {
@@ -82,20 +141,22 @@
         })
             .then(response => {
                 if (response.ok) {
-                    return response.text(); // 성공 시 응답 처리
+                    return response.text();
                 } else {
                     throw new Error("비밀번호 변경 실패");
                 }
             })
             .then(data => {
-                console.log("비밀번호 변경 성공:", data);
                 alert("비밀번호가 성공적으로 변경되었습니다.");
+                window.location.href = '/home'; // /home 경로로 리디렉션
             })
             .catch(error => {
-                console.error("Error:", error);
                 alert("비밀번호 변경 중 오류가 발생했습니다.");
             });
     }
+
 </script>
+
+<script th:src="@{/js/Home.js}"></script>
 </body>
 </html>


### PR DESCRIPTION
Home.css : 팔로우 취소 팝업창 fixed 변경
following.html : x 버튼 누를시 바로 팔로우 취소 요청 보냄, js로 폼 제출 이벤트 가로채고 팝업을 통해 통제
followcancel_popup.html : 팔로우 닫기, 취소하기 버튼에 함수 추가
UserRepository : 이메일, 닉네임 중복 확인 메소드 추가
CustomAuthenticationFailureHandler : 로그인 실패시 응답 메서드
Home.css : 로그인 에러 메시지 표시, 로그인 팝업 fixed
StoryRepository : 검색 결과 역순으로 받아오기 수정, 특정 키워드가 포함된 스토리 중 가장 최근거 가져오기로 변경
특정 키워드가 포함된 스토리 중 가장 최근거 가져오기 변경에 맞춘 수정 : RisingService,SearchService, StoryService
검색 결과 역순으로 받아오기 변경에 맞춘 수정 : SearchController
SecurityConfig : 로그인 실패 시 CustomAuthenticationFailureHandler 호출
RisingController : 급상승 엔티티 방문시에도 검색 횟수 증가
PasswordResetTokenService, Repository : 토큰을 user을 통해 찾기
PasswordResetToken : 토큰 만료 추가
PasswordController : 토큰 만료 + 중복 시 삭제 후 재설정 토큰 발행, 토큰이 이미 존재할 경우 예외 처리
Home.js : 로그인 실패시 오류 메시지 표시, 비밀번호 찾기 메일 전송시 완료 팝업 표시, 실패시 에러메시지 alert
pwfind_popup.html : AJAX 폼 제출 + js 활용으로 수정
pwfindsendnotice_popup.html : 확인 버튼 누르면 팝업 닫기
resetpassword.html : 서버에서 제대로 보이도록 수정
Home.html : 비밀번호 찾기 메일 전송 완료 팝업 추가